### PR TITLE
fix: Docker warning when using frapsoft/openssl on arm64 system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,12 @@ unit-test:
 bdd-test: clean rp-adapter-rest-docker issuer-adapter-rest-docker mock-issuer-docker mock-webhook-docker mock-issuer-login-consent-docker generate-test-keys
 	@scripts/check_integration.sh
 
+# TODO (#675): frapsoft/openssl only has an amd64 version. While this does work under amd64 and arm64 Mac OS currently,
+#               we should add an arm64 version for systems that can only run arm64 code.
 .PHONY: generate-test-keys
 generate-test-keys: clean
 	@mkdir -p -p test/bdd/fixtures/keys/tls
-	@docker run -i --rm \
+	@docker run -i --platform linux/amd64 --rm \
 		-v $(abspath .):/opt/workspace/edge-adapter \
 		--entrypoint "/opt/workspace/edge-adapter/scripts/generate_test_keys.sh" \
 		frapsoft/openssl


### PR DESCRIPTION
Resolved a warning from Docker that would get printed when running the generate-test-keys Makefile target on an arm64 system. The warning from Docker alerts you that the image for frapsoft/openssl is for amd64, which doesn't match the system you're on (when using an arm64-based OS). To resolve the warning, you have to either use an image that matches the system architecture, or explicitly state the platform using the --platform flag. In this case, there is only an amd64 version of frapsoft/openssl, so I added the explicit flag to resolve the warning. I also added a TODO for us to find an arm64 alternative in the future (although the amd64 version of frapsoft/openssl does seem to work fine on arm64 Mac OS currently, presumably due to Apple's Rosetta translation layer or some other emulation layer).

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>